### PR TITLE
Enable podman-restart service on user systemd initialization

### DIFF
--- a/.local/share/bin/init-user-env.sh
+++ b/.local/share/bin/init-user-env.sh
@@ -27,6 +27,7 @@ if [[ "$(uname)" == "Linux" ]] && ! test -f /.dockerenv; then
 
     if command -v podman &>/dev/null && command -v systemctl &>/dev/null; then
         systemctl --user enable --now podman.socket 2>/dev/null || true
+        systemctl --user enable --now podman-restart.service 2>/dev/null || true
     fi
 
     if command -v nvidia-ctk &>/dev/null; then


### PR DESCRIPTION
## Summary
Added automatic enablement of the `podman-restart.service` unit during user environment initialization on Linux systems with podman installed.

## Changes
- Enable and start `podman-restart.service` via systemctl during user environment setup, alongside the existing `podman.socket` enablement
- This ensures podman containers are automatically restarted on system boot when using rootless podman with user systemd

## Implementation Details
- The new systemctl command follows the same pattern as the existing `podman.socket` enablement
- Error output is suppressed and failures are ignored (`2>/dev/null || true`) to maintain non-blocking initialization behavior
- Only executes on Linux systems with both podman and systemctl available

https://claude.ai/code/session_015skKawR1XyWdUpw3FwTTV5