### PR TITLE
refactor: Prune nvim plugin list, replace archived nvim-treesitter

### DIFF
--- a/.config/nvim/lua/config.lua
+++ b/.config/nvim/lua/config.lua
@@ -136,10 +136,16 @@ require("lazy").setup({
     },
   },
 
-  -- Syntax highlighting and code navidation
+  -- Syntax highlighting and code navigation.
+  -- nvim-treesitter (the parser manager / install framework) was archived in
+  -- April 2026. Parser installation is now done in-place in
+  -- `plugins_config/treesitter_conf.lua` against upstream parser repos.
+  -- nvim-treesitter-textobjects works standalone and is the entry point that
+  -- loads our treesitter config.
   {
     "nvim-treesitter/nvim-treesitter-textobjects",
     branch = "main",
+    lazy = false,
     init = function()
       -- Disable entire built-in ftplugin mappings to avoid conflicts.
       -- See https://github.com/neovim/neovim/tree/master/runtime/ftplugin
@@ -153,30 +159,8 @@ require("lazy").setup({
       -- vim.g.no_go_maps = true
     end,
     config = function()
-      -- put your config here
-    end,
-  },
-  {
-    "nvim-treesitter/nvim-treesitter",
-    lazy = false,
-    build = ":TSUpdate",
-    dependencies = {
-      "nvim-treesitter/nvim-treesitter-textobjects",
-    },
-    init = function(plugin)
-      -- PERF: add nvim-treesitter queries to the rtp and it's custom query
-      -- predicates early This is needed because a bunch of plugins no longer
-      -- `require("nvim-treesitter")`, which no longer trigger the
-      -- **nvim-treesitter** module to be loaded in time.
-      -- Luckily, the only things that those plugins need are the custom
-      -- queries, which we make available during startup.
-      require("lazy.core.loader").add_to_rtp(plugin)
-    end,
-    ---@param opts TSConfig
-    config = function(_, opts) -- luacheck: no unused args
       require("plugins_config/treesitter_conf")
     end,
-    cmd = { "TSUpdateSync", "TSUpdate", "TSInstall" },
   },
   -- # Completion
 
@@ -219,7 +203,6 @@ require("lazy").setup({
     end,
     dependencies = {
       "nvim-tree/nvim-web-devicons",
-      "williamboman/mason-lspconfig.nvim",
       "saghen/blink.cmp",
     },
   },
@@ -334,10 +317,6 @@ require("lazy").setup({
       require("plugins_config/ctrlp_conf")
     end,
   },
-  -- HG plugin
-  {
-    "ludovicchabant/vim-lawrencium",
-  },
   -- Git plugin
   {
     "tpope/vim-fugitive",
@@ -414,7 +393,6 @@ require("lazy").setup({
     dependencies = { -- optional packages
       "ray-x/guihua.lua",
       "neovim/nvim-lspconfig",
-      "nvim-treesitter/nvim-treesitter",
     },
     config = function()
       -- TODO: not sure if this actually does anything
@@ -432,44 +410,6 @@ require("lazy").setup({
     ft = { "go", "gomod" },
     -- if you need to install/update all binaries
     build = ':lua require("go.install").update_all_sync()',
-  },
-  {
-    "golang/vscode-go",
-    ft = "go",
-    build = function(plugin)
-      -- Pop top level `.source.go` key from the vscode json. It is not
-      -- compatible with both vsnip and luasnip
-      vim.print("Got plugin path " .. plugin.dir)
-      local snippets_path = plugin.dir .. "/extension/snippets/go.json"
-
-      vim.print("Got file path " .. snippets_path)
-      local snippet_file = io.open(snippets_path, "r")
-
-      vim.print("Reading " .. snippets_path)
-      ---@diagnostic disable-next-line: need-check-nil
-      local initial_json = snippet_file:read("*a")
-      ---@diagnostic disable-next-line: need-check-nil
-      snippet_file:close()
-
-      vim.print("Decoding " .. snippets_path)
-      local decoded_json = vim.json.decode(initial_json)
-
-      if decoded_json[".source.go"] == nil then
-        return
-      end
-
-      vim.print("Encoding " .. snippets_path)
-      local fixed_json = vim.json.encode(decoded_json[".source.go"])
-
-      vim.print("Writing " .. snippets_path)
-      snippet_file = io.open(snippets_path, "w+")
-      ---@diagnostic disable-next-line: need-check-nil
-      snippet_file:write(fixed_json)
-      ---@diagnostic disable-next-line: need-check-nil
-      snippet_file:close()
-
-      vim.print("Written " .. snippets_path)
-    end,
   },
   -- sudo snap install rustup --classic,
   -- sudo snap install rust-analyzer --beta,
@@ -784,7 +724,6 @@ require("lazy").setup({
     "olimorris/codecompanion.nvim",
     dependencies = {
       "nvim-lua/plenary.nvim",
-      "nvim-treesitter/nvim-treesitter",
     },
     config = function()
       require("codecompanion").setup({
@@ -875,7 +814,6 @@ require("lazy").setup({
         desc = "Toggle split/join arguments",
       },
     },
-    dependencies = { "nvim-treesitter/nvim-treesitter" },
     opts = {
       use_default_keymaps = false,
     },
@@ -922,6 +860,10 @@ require("lazy").setup({
   {
     "mbbill/undotree",
   },
+  -- Vendored under `.config/nvim/plugins/smart-open.nvim` because we need its
+  -- git worktree detection (treats sibling worktrees as part of the same
+  -- frecency scope) which other frecency pickers don't provide. sqlite.lua is
+  -- a low-maintenance native-code dependency; revisit if it breaks.
   {
     "danielfalk/smart-open.nvim",
     dir = vim.fn.stdpath("config") .. "/plugins/smart-open.nvim",

--- a/.config/nvim/lua/plugins_config/mason_lspconfig_conf.lua
+++ b/.config/nvim/lua/plugins_config/mason_lspconfig_conf.lua
@@ -1,5 +1,0 @@
-require("mason-lspconfig").setup({
-  automatic_installation = {
-    exclude = { "gopls", "pyright", "basedpyright" },
-  },
-})

--- a/.config/nvim/lua/plugins_config/treesitter_conf.lua
+++ b/.config/nvim/lua/plugins_config/treesitter_conf.lua
@@ -1,3 +1,17 @@
+-- ============================================================================
+-- Native treesitter parser installer.
+--
+-- Replaces the archived nvim-treesitter plugin with a minimal in-place
+-- installer:
+--   1. Clone parser sources from upstream tree-sitter repos
+--   2. Compile parser.c (+ scanner.{c,cc} if present) into <lang>.so
+--   3. Copy upstream queries into runtimepath
+--   4. Prepend the install dir to runtimepath so vim.treesitter finds them
+--
+-- Installs run asynchronously via vim.system(); the smoke test waits up to
+-- 120s for parsers to become loadable.
+-- ============================================================================
+
 -- This is a workaround to prevent an error when we open file with an existing
 -- .swp file.
 -- https://github.com/neovim/neovim/issues/26192
@@ -22,23 +36,217 @@ vim.api.nvim_create_autocmd("FileType", {
   end,
 })
 
--- Install parsers that we want available
 local M = {}
 
-M.ensure_installed = {
-  "bash",
-  "c",
-  "go",
-  "lua",
-  "markdown",
-  "markdown_inline",
-  "proto",
-  "python",
-  "rust",
-  "zsh",
+---@class ParserSpec
+---@field url string Git URL to clone from
+---@field location string|nil Subdirectory inside the repo (for monorepos)
+
+---@type table<string, ParserSpec>
+M.parsers = {
+  bash = { url = "https://github.com/tree-sitter/tree-sitter-bash" },
+  c = { url = "https://github.com/tree-sitter/tree-sitter-c" },
+  go = { url = "https://github.com/tree-sitter/tree-sitter-go" },
+  lua = { url = "https://github.com/tree-sitter-grammars/tree-sitter-lua" },
+  markdown = {
+    url = "https://github.com/tree-sitter-grammars/tree-sitter-markdown",
+    location = "tree-sitter-markdown",
+  },
+  markdown_inline = {
+    url = "https://github.com/tree-sitter-grammars/tree-sitter-markdown",
+    location = "tree-sitter-markdown-inline",
+  },
+  proto = { url = "https://github.com/mitchellh/tree-sitter-proto" },
+  python = { url = "https://github.com/tree-sitter/tree-sitter-python" },
+  rust = { url = "https://github.com/tree-sitter/tree-sitter-rust" },
 }
 
-require("nvim-treesitter").install(M.ensure_installed)
+-- ensure_installed lists the language ids the smoke test verifies.
+M.ensure_installed = vim.tbl_keys(M.parsers)
+table.sort(M.ensure_installed)
+
+-- zsh files use the bash treesitter parser. Avoids a duplicate parser binary.
+pcall(vim.treesitter.language.register, "bash", "zsh")
+
+local install_dir = vim.fn.stdpath("data") .. "/treesitter"
+local parser_dir = install_dir .. "/parser"
+local queries_dir = install_dir .. "/queries"
+local repos_dir = install_dir .. "/repos"
+
+vim.fn.mkdir(parser_dir, "p")
+vim.fn.mkdir(queries_dir, "p")
+vim.fn.mkdir(repos_dir, "p")
+
+vim.opt.runtimepath:prepend(install_dir)
+
+---@param msg string
+---@param level integer|nil
+local function log(msg, level)
+  vim.schedule(function()
+    vim.notify("[treesitter] " .. msg, level or vim.log.levels.DEBUG)
+  end)
+end
+
+-- Deduplicate clones when multiple parsers share a repo (e.g. markdown +
+-- markdown_inline both live in tree-sitter-markdown).
+---@type table<string, fun(repo_dir: string|nil)[]>
+local clone_callbacks = {}
+
+---@param url string
+---@param on_done fun(repo_dir: string|nil)
+local function ensure_repo(url, on_done)
+  local repo_dir = repos_dir .. "/" .. vim.fn.sha256(url):sub(1, 16)
+
+  if vim.uv.fs_stat(repo_dir) then
+    on_done(repo_dir)
+    return
+  end
+
+  if clone_callbacks[url] then
+    table.insert(clone_callbacks[url], on_done)
+    return
+  end
+  clone_callbacks[url] = { on_done }
+
+  log("cloning " .. url)
+  vim.system({
+    "git",
+    "clone",
+    "--depth",
+    "1",
+    "--quiet",
+    url,
+    repo_dir,
+  }, { text = true }, function(result)
+    vim.schedule(function()
+      local cbs = clone_callbacks[url] or {}
+      clone_callbacks[url] = nil
+      if result.code ~= 0 then
+        log(
+          "clone failed for " .. url .. ": " .. (result.stderr or ""),
+          vim.log.levels.ERROR
+        )
+        for _, cb in ipairs(cbs) do
+          cb(nil)
+        end
+        return
+      end
+      for _, cb in ipairs(cbs) do
+        cb(repo_dir)
+      end
+    end)
+  end)
+end
+
+---@param src string
+---@param dst string
+---@return boolean
+local function copy_file(src, dst)
+  local infile = io.open(src, "rb")
+  if not infile then
+    return false
+  end
+  local content = infile:read("*a")
+  infile:close()
+  local outfile = io.open(dst, "wb")
+  if not outfile then
+    return false
+  end
+  outfile:write(content)
+  outfile:close()
+  return true
+end
+
+---@param source_dir string
+---@param lang string
+local function install_queries(source_dir, lang)
+  local queries_src = source_dir .. "/queries"
+  if not vim.uv.fs_stat(queries_src) then
+    return
+  end
+  local queries_dest = queries_dir .. "/" .. lang
+  vim.fn.mkdir(queries_dest, "p")
+  for _, file in ipairs(vim.fn.glob(queries_src .. "/*.scm", false, true)) do
+    local basename = vim.fn.fnamemodify(file, ":t")
+    copy_file(file, queries_dest .. "/" .. basename)
+  end
+end
+
+---@param lang string
+---@param spec ParserSpec
+---@param repo_dir string
+local function build_parser(lang, spec, repo_dir)
+  local source_dir = repo_dir
+  if spec.location then
+    source_dir = repo_dir .. "/" .. spec.location
+  end
+  local src = source_dir .. "/src"
+  local parser_c = src .. "/parser.c"
+  if not vim.uv.fs_stat(parser_c) then
+    log("no parser.c found for " .. lang, vim.log.levels.ERROR)
+    return
+  end
+
+  local has_c = vim.uv.fs_stat(src .. "/scanner.c") ~= nil
+  local has_cc = vim.uv.fs_stat(src .. "/scanner.cc") ~= nil
+  local compiler = has_cc and "c++" or "cc"
+  local parser_so = parser_dir .. "/" .. lang .. ".so"
+
+  ---@type string[]
+  local args = {
+    compiler,
+    "-o",
+    parser_so,
+    "-shared",
+    "-Os",
+    "-fPIC",
+    "-I",
+    src,
+    parser_c,
+  }
+  if has_c then
+    table.insert(args, src .. "/scanner.c")
+  end
+  if has_cc then
+    table.insert(args, src .. "/scanner.cc")
+  end
+
+  log("building " .. lang)
+  vim.system(args, { text = true }, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        log(
+          "build failed for " .. lang .. ": " .. (result.stderr or ""),
+          vim.log.levels.ERROR
+        )
+        return
+      end
+      install_queries(source_dir, lang)
+      log("installed " .. lang)
+    end)
+  end)
+end
+
+---@param lang string
+---@param spec ParserSpec
+local function install_parser(lang, spec)
+  local parser_so = parser_dir .. "/" .. lang .. ".so"
+  if vim.uv.fs_stat(parser_so) then
+    return
+  end
+  ensure_repo(spec.url, function(repo_dir)
+    if not repo_dir then
+      return
+    end
+    build_parser(lang, spec, repo_dir)
+  end)
+end
+
+vim.schedule(function()
+  for lang, spec in pairs(M.parsers) do
+    install_parser(lang, spec)
+  end
+end)
 
 -- Textobjects config (handled by nvim-treesitter-textobjects)
 require("nvim-treesitter-textobjects").setup({


### PR DESCRIPTION
## Summary

Plugin audit follow-up. Removes unused/redundant plugins and replaces the archived `nvim-treesitter` with a minimal in-place parser installer.

### Changes

**Replaced**
- `nvim-treesitter/nvim-treesitter` (archived April 2026) → in-place async installer in `plugins_config/treesitter_conf.lua`. Clones upstream parser repos, compiles `parser.c` + `scanner.{c,cc}` with `cc`/`c++`, copies queries into runtimepath. Deduplicates clones for shared monorepos (markdown). Registers `zsh` filetype as `bash` parser instead of installing a duplicate parser binary.
- `nvim-treesitter-textobjects` is now the entry point that loads our treesitter config (works standalone post-rewrite).

**Removed**
- `williamboman/mason-lspconfig.nvim` — orphaned dependency, never configured (no `mason.nvim` in the spec, `mason_lspconfig_conf.lua` was never required). Deleted the dead config file.
- `golang/vscode-go` — unused; the snippet-extraction `build` hook was fragile.
- `ludovicchabant/vim-lawrencium` — Mercurial, unused.

**Cleaned up transitive deps**
- Removed `nvim-treesitter/nvim-treesitter` from `go.nvim`, `codecompanion.nvim`, and `treesj` dependency lists. Otherwise lazy.nvim would silently re-install the archived plugin.

**Documented**
- Added comment to `smart-open.nvim` explaining why it stays vendored (git-worktree-aware frecency scope, not provided by other pickers). The `sqlite.lua` native-code dependency is flagged as a maintenance risk.

### Implementation notes — parser installer

- Install dir: `vim.fn.stdpath("data") .. "/treesitter"` (parser/, queries/, repos/), prepended to runtimepath.
- Async via `vim.system()` with `vim.schedule()` callbacks. Idempotent — skips if `<lang>.so` already exists.
- Clone dedupe by URL (markdown + markdown_inline share one clone).
- Compiler chosen based on presence of `scanner.cc` vs `scanner.c`.
- Failures are logged via `vim.notify` but don't crash; smoke test will fail loudly if a parser isn't loadable within 120s.

### Test plan

- [ ] Neovim Plugin Smoke Test workflow passes (validates all plugins load and all 9 treesitter parsers compile within 120s)
- [ ] First-time install in CI completes within smoke-test timeout (8 git clones + 9 builds)
- [ ] Second invocation skips installs (idempotent check via `fs_stat`)
- [ ] `gT`/`gt` (bufferline), `<CR>`/`<BS>` (treesitter incremental selection), `]m`/`[m` etc. (textobjects) still work after the change

https://claude.ai/code/session_01WWeNMwc4XPj4GNSHsquMcv