### PR TITLE
chore: neovim plugin audit TODO updates (May 2026)

### DIFF
--- a/.config/nvim/lua/config.lua
+++ b/.config/nvim/lua/config.lua
@@ -327,7 +327,8 @@ require("lazy").setup({
       require("plugins_config/neotree_conf")
     end,
     dependencies = {
-      -- TODO: drop plenary when neo-tree v4.0 ships
+      -- TODO(urgent): drop plenary when neo-tree v4.0 ships (plenary
+      -- sunsets June 30, 2026).
       -- https://github.com/nvim-neo-tree/neo-tree.nvim/issues/2014
       "nvim-lua/plenary.nvim",
       "echasnovski/mini.icons",
@@ -363,8 +364,8 @@ require("lazy").setup({
       require("plugins_config/vim_go_conf")
     end,
   },
-  -- TODO: guihua.lua (go.nvim UI dep) is stale (no commits in 2+ years).
-  -- If it breaks, go.nvim may still work without it (UI features degrade).
+  -- NOTE: guihua.lua (go.nvim UI dep) is a single-author project tightly
+  -- coupled to ray-x's ecosystem. Active as of May 2026 but small user base.
   {
     "ray-x/go.nvim",
     dependencies = { -- optional packages
@@ -467,7 +468,8 @@ require("lazy").setup({
     end,
     lazy = false, -- This plugin is already lazy
   },
-  -- TODO: remove when neo-tree and telescope drop plenary
+  -- TODO(urgent): plenary.nvim sunsets June 30, 2026 (critical fixes only).
+  -- Remove when neo-tree and telescope drop the dependency.
   -- neo-tree v4.0: https://github.com/nvim-neo-tree/neo-tree.nvim/issues/2014
   -- telescope: https://github.com/nvim-telescope/telescope.nvim/pull/3647
   {
@@ -494,8 +496,9 @@ require("lazy").setup({
       require("plugins_config/quickui_conf")
     end,
   },
-  -- TODO: bufferline.nvim is stale (last commit Jan 2025). Consider
-  -- alternatives: barbar.nvim, mini.tabline, or going tab-less.
+  -- TODO: bufferline.nvim is stale (last commit Jan 2025, 77 open issues,
+  -- 23 unmerged PRs). Consider replacing with mini.tabline (echasnovski,
+  -- actively maintained) or a native 'tabline' function (~30 lines of Lua).
   {
     "akinsho/bufferline.nvim",
     version = "*",
@@ -736,8 +739,10 @@ require("lazy").setup({
   },
   -- Vendored under `.config/nvim/plugins/smart-open.nvim` because we need its
   -- git worktree detection (treats sibling worktrees as part of the same
-  -- frecency scope) which other frecency pickers don't provide. sqlite.lua is
-  -- a low-maintenance native-code dependency; revisit if it breaks.
+  -- frecency scope) which other frecency pickers don't provide.
+  -- WARN: sqlite.lua (kkharji) is effectively unmaintained (last real commit
+  -- Apr 2024, 19 unanswered issues). Native FFI binding = supply-chain risk.
+  -- Fallback: telescope.builtin.oldfiles + custom recent_and_modified_files.
   {
     "danielfalk/smart-open.nvim",
     dir = vim.fn.stdpath("config") .. "/plugins/smart-open.nvim",


### PR DESCRIPTION
## Summary

Updates TODO comments in `.config/nvim/lua/config.lua` based on a full audit of all neovim plugins (maintenance status, security, native replacements, alternatives).

- Fix incorrect "guihua.lua is stale" comment (it's actually active as of May 2026)
- Mark plenary.nvim TODOs as urgent (sunsets June 30, 2026)
- Add specific replacement guidance for bufferline.nvim (mini.tabline or native)
- Add supply-chain warning for sqlite.lua (unmaintained since Apr 2024)

## Full Audit Report

### KEEP — No action needed (33 plugins)

All actively maintained, no native replacements, no better alternatives:
gruvbox.nvim, mini.icons, mini.pairs, nvim-treesitter-textobjects, friendly-snippets, blink.cmp, nvim-lspconfig, conform.nvim, flash.nvim, vim-fugitive, gitsigns.nvim, diffview.nvim (dlyongemallo fork), neogit, neo-tree.nvim, rustaceanvim, nvim-dap, please.nvim, go.nvim, guihua.lua, lualine.nvim, dropbar.nvim, telescope.nvim, telescope-fzf-native.nvim, telescope-live-grep-args.nvim, rainbow-delimiters.nvim, indent-blankline.nvim, vim-matchup, trouble.nvim, which-key.nvim, treesj, nvim-early-retirement, auto-session, ctrlp.vim (intentional)

### WARN — Watch closely (5 plugins)

| Plugin | Concern |
|--------|---------|
| `akinsho/bufferline.nvim` | Stale since Jan 2025 (16+ months, 77 issues, 23 unmerged PRs) |
| `skywind3000/vim-quickui` | Legacy VimScript; existing TODO to replace with `vim.ui.select` |
| `kkharji/sqlite.lua` | Unmaintained since Apr 2024; native FFI = supply-chain risk |
| `nvim-lua/plenary.nvim` | **Sunsets June 30, 2026** (5 weeks away) |
| `MunifTanjim/nui.nvim` | Last commit Jun 2025 (~11 months); neo-tree dependency |

### Security Notes

- **sqlite.lua**: Highest risk — unmaintained native FFI binding
- **blink.cmp**: Downloads prebuilt Rust binary (mitigate: build from source)
- **telescope-fzf-native.nvim**: Native C (cmake), but maintained by nvim-telescope org

### No plugins need immediate removal or replacement

The config is well-maintained and already uses native solutions where available (undotree, document highlight, treesitter installer, fixeol).

## Test plan

- [ ] CI smoke test passes (plugins load, treesitter parsers compile)
- [ ] CI deprecation check passes
- [ ] Changes are comment-only — no functional impact

https://claude.ai/code/session_018tXXUPu5eELaXfhRngLkPv

---
_Generated by [Claude Code](https://claude.ai/code/session_018tXXUPu5eELaXfhRngLkPv)_