### PR TITLE
Neovim plugin audit (May 2026)

### DIFF
--- a/.config/nvim/lua/config.lua
+++ b/.config/nvim/lua/config.lua
@@ -363,8 +363,6 @@ require("lazy").setup({
       require("plugins_config/vim_go_conf")
     end,
   },
-  -- TODO: guihua.lua (go.nvim UI dep) is stale (no commits in 2+ years).
-  -- If it breaks, go.nvim may still work without it (UI features degrade).
   {
     "ray-x/go.nvim",
     dependencies = { -- optional packages


### PR DESCRIPTION
## Summary

- Audited all 34 active plugins in `.config/nvim/lua/config.lua`
- Removed outdated TODO comment claiming `guihua.lua` is stale — it was actively updated May 2026
- No plugins need replacing or removing; the config is already using modern choices

## Audit findings

### KEEP (34 plugins)
All active plugins are well-maintained with no native neovim 0.12 replacements. The config has already migrated away from deprecated plugins (undotree → native, vim-commentary → native gc, vim-illuminate → native document highlight).

### WARN (6 items to monitor)

| Plugin | Concern |
|--------|---------|
| **nvim-lua/plenary.nvim** | **CRITICAL**: Archiving June 30, 2026. Affects neo-tree and telescope. Track migration: telescope PR #3647, neo-tree issue #2014. |
| **kkharji/sqlite.lua** | Poorly maintained, broken CI, inactive author. Dependency of vendored smart-open.nvim. |
| **danielfalk/smart-open.nvim** | Beta, depends on sqlite.lua. Vendored mitigates some risk. |
| **akinsho/bufferline.nvim** | No commits since Jan 2025. Existing TODO tracks this. |
| **MunifTanjim/nui.nvim** | Last commit Jun 2025. Neo-tree v4.0 aims to drop it. |
| **ray-x/guihua.lua** | Previous TODO was outdated — actually active (May 2026). **Removed the stale TODO in this PR.** |

### REMOVE / REPLACE
None needed.

### Redundancy
None found. vim-fugitive + neogit + gitsigns serve complementary roles. ctrlp + telescope serve different use cases.

## Code change

Removed 2-line outdated comment above `ray-x/go.nvim` that incorrectly claimed `guihua.lua` had no commits in 2+ years.

## Test plan

- [ ] Verify nvim starts without errors (`nvim --headless +qa`)
- [ ] Verify smoke test passes (`.config/nvim/lua/smoke_test.lua`)

https://claude.ai/code/session_01Ah315VGUKsB9DMmuSmMnoS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ah315VGUKsB9DMmuSmMnoS)_