### PR TITLE
nvim: plugin audit — reduce lspconfig coupling, remove outdated TODO

### DIFF
--- a/.config/nvim/lua/config.lua
+++ b/.config/nvim/lua/config.lua
@@ -363,8 +363,6 @@ require("lazy").setup({
       require("plugins_config/vim_go_conf")
     end,
   },
-  -- TODO: guihua.lua (go.nvim UI dep) is stale (no commits in 2+ years).
-  -- If it breaks, go.nvim may still work without it (UI features degrade).
   {
     "ray-x/go.nvim",
     dependencies = { -- optional packages

--- a/.config/nvim/lua/plugins_config/lsp_conf.lua
+++ b/.config/nvim/lua/plugins_config/lsp_conf.lua
@@ -1,9 +1,6 @@
-local lspconfig_defaults = require("lspconfig.util").default_config
-lspconfig_defaults.capabilities = vim.tbl_deep_extend(
-  "force",
-  lspconfig_defaults.capabilities,
-  require("blink.cmp").get_lsp_capabilities()
-)
+vim.lsp.config("*", {
+  capabilities = require("blink.cmp").get_lsp_capabilities(),
+})
 
 -- Uncomment for debug and use LspLog
 -- vim.lsp.set_log_level("debug")
@@ -457,7 +454,6 @@ vim.lsp.config("gopls", {
       },
     },
   },
-  capabilities = require("blink.cmp").get_lsp_capabilities(),
 })
 vim.lsp.enable("gopls")
 


### PR DESCRIPTION
## Summary

Full audit of all neovim plugins in `.config/nvim/lua/config.lua`. This PR implements the safe, minimal changes from the audit findings. The full report is below for reference.

### Changes in this PR

- **`lsp_conf.lua`**: Replace `lspconfig.util.default_config` capability mutation with native `vim.lsp.config("*", ...)` — the rest of the file already uses the native 0.11+ API, this was the last internal lspconfig coupling
- **`lsp_conf.lua`**: Remove redundant `capabilities` override in gopls config (now inherited from the `"*"` global config)
- **`config.lua`**: Remove outdated TODO claiming guihua.lua is stale with "no commits in 2+ years" — it has recent commits (May 2026)

---

## Full Plugin Audit Report

**Config**: `.config/nvim/lua/config.lua` | **Requires**: nvim >= 0.12 | **Plugin manager**: lazy.nvim

*Skipped: disabled plugins (`vim-dispatch`, `vim-go`), user-owned plugin (`fspv/sourcegraph.nvim`)*

---

### KEEP — 28 plugins

Actively maintained, no native replacement, no clearly better alternative.

| Plugin | Last commit | Stars | Notes |
|--------|-------------|-------|-------|
| `ellisonleao/gruvbox.nvim` | Apr 2026 | 2.5k | Active colorscheme |
| `nvim-treesitter/nvim-treesitter-textobjects` | Apr 2026 | 2.8k | No native textobject replacement |
| `rafamadriz/friendly-snippets` | Jan 2026 | 2.7k | Community snippet collection, blink.cmp dep |
| `saghen/blink.cmp` | Jun 2026 | 6.3k | Native completion (0.12 `autocomplete`) lacks multi-source/fuzzy |
| `stevearc/conform.nvim` | May 2026 | 5.2k | No native multi-formatter orchestration |
| `echasnovski/mini.pairs` | Vendored | — | No native auto-pairs |
| `echasnovski/mini.icons` | Vendored | — | No native icon support |
| `folke/flash.nvim` | Oct 2025 | 4.1k | Feature-complete, stable |
| `ctrlpvim/ctrlp.vim` | Apr 2026 | 5.7k | Intentionally kept for buffer switching |
| `tpope/vim-fugitive` | Mar 2026 | 21.7k | Irreplaceable git CLI interface |
| `lewis6991/gitsigns.nvim` | Jun 2026 | 6.9k | No native git signs |
| `dlyongemallo/diffview.nvim` | Jun 2026 | 222 | Active fork of archived `sindrets/diffview.nvim` |
| `NeogitOrg/neogit` | May 2026 | 5.4k | Magit-like interface, complements fugitive |
| `nvim-neo-tree/neo-tree.nvim` | Jun 2026 | 5.5k | No native file tree |
| `ray-x/go.nvim` | Jun 2026 | 2.6k | Go-specific tooling |
| `ray-x/guihua.lua` | May 2026 | 188 | go.nvim UI dep — **active again** |
| `mrcjkb/rustaceanvim` | Jun 2026 | 3k | Excellent maintenance (250 releases) |
| `mfussenegger/nvim-dap` | May 2026 | 7.1k | Debug adapter protocol |
| `marcuscaisey/please.nvim` | May 2026 | 11 | Niche but well-maintained |
| `nvim-telescope/telescope.nvim` | May 2026 | 19.5k | Used extensively for LSP navigation |
| `nvim-telescope/telescope-fzf-native.nvim` | May 2026 | 1.8k | Native fzf sorter |
| `nvim-telescope/telescope-live-grep-args.nvim` | Apr 2026 | 899 | Ripgrep args passthrough |
| `HiPhish/rainbow-delimiters.nvim` | May 2026 | 869 | No native rainbow brackets |
| `lukas-reineke/indent-blankline.nvim` | Feb 2026 | 4.9k | No native indent guides |
| `andymass/vim-matchup` | May 2026 | 1.9k | Treesitter-aware `%` beyond built-in matchit |
| `folke/trouble.nvim` | Oct 2025 | 6.8k | Diagnostic panel not replaceable natively |
| `folke/which-key.nvim` | Oct 2025 | 7.2k | No native keymap discovery popup |
| `Wansmer/treesj` | May 2026 | 1.3k | Unique treesitter split/join |
| `chrisgrieser/nvim-early-retirement` | Apr 2026 | 254 | Small scope, clean issue tracker |
| `rmagatti/auto-session` | May 2026 | 1.8k | No native session management |
| `nvim-lualine/lualine.nvim` | May 2026 | 8k | Active, multiple contributors |
| `Bekaboo/dropbar.nvim` | May 2026 | 1.6k | Very active winbar plugin |
| `neovim/nvim-lspconfig` | Jun 2026 | 13.7k | Still needed for default server configs (cmd, filetypes) for 15 servers |

### WARN — 6 plugins

Still needed but have concerning maintenance or security signals.

**1. `akinsho/bufferline.nvim` — Stale (18 months)**
- Last commit: Jan 2025. Issues from 2026 going unanswered.
- Risk: Will eventually break with nvim API changes.
- Alternatives: `barbar.nvim` (active), `mini.tabline`, or going tab-less.
- Config already has TODO noting this.

**2. `nvim-lua/plenary.nvim` — Deprecated, archiving Jun 30 2026**
- README states it is no longer actively maintained.
- Dependents: `neo-tree.nvim`, `telescope.nvim`.
- neo-tree v4.0 drops plenary (#2014). Telescope migration tracked at #3647.
- Config already has TODOs tracking both.

**3. `MunifTanjim/nui.nvim` — Stale (1 year)**
- Last commit: Jun 2025. No 2026 activity.
- Risk: Neo-tree dependency. If nui.nvim breaks, neo-tree breaks.
- Watch: Neo-tree v4.0 may also drop nui.nvim.

**4. `kkharji/sqlite.lua` — Stale (15 months), security concern**
- Last commit: Mar 2025. Multiple unanswered issues.
- Security: Open issue #182 — SQL string escaping error. Native-code plugin (C FFI to SQLite) increases trust surface.
- Risk: Dependency of vendored `smart-open.nvim`.

**5. `danielfalk/smart-open.nvim` — Slowing (7 months)**
- Last commit: Nov 2025. Limited maintainer responses.
- Depends on stale sqlite.lua. Vendored locally so breakage is contained.
- Alternative: `telescope-frecency.nvim` (active).

**6. `skywind3000/vim-quickui` — Maintenance concerns**
- Open/closed ratio: 39/30 (more open than closed). Many issues unanswered.
- Vimscript plugin in a Lua-heavy config.
- Config already has TODO: "replace vim-quickui with vim.ui.select based menu."

### REMOVE — 0 plugins

No plugin can be trivially removed. `nvim-lspconfig` is the closest candidate (config already uses native `vim.lsp.config()`/`vim.lsp.enable()` for all servers), but it still provides default server configs (cmd, filetypes, root_dir) for 15 servers that would need manual specification.

### REPLACE — 0 plugins

No plugin has a clearly superior drop-in replacement that justifies migration effort right now.

### Redundancy check — No issues found

- `vim-fugitive` + `neogit` + `gitsigns` + `diffview` all serve distinct purposes
- `telescope` + `ctrlp` — intentionally kept per user preference
- `conform.nvim` + LSP formatting — complementary (conform handles non-LSP formatters)

### Security — No CVEs found

No known CVEs affect any plugin in this config. The only tangential CVE is CVE-2026-46483 (command injection in Vim's built-in tar.vim), patched in nvim 0.10.3+. `blink.cmp` ships precompiled Rust binaries (extra trust surface vs pure Lua). `sqlite.lua` has the open escaping issue noted above.

## Test plan

- [ ] Verify `lsp_conf.lua` changes: open a file with an LSP server (e.g. `.lua`, `.go`, `.py`), confirm completion works and LSP attaches with correct capabilities
- [ ] Verify gopls specifically still gets blink.cmp capabilities via the global `"*"` config
- [ ] Run smoke test: `.config/nvim/lua/smoke_test.lua` passes

https://claude.ai/code/session_019woWQnM6md3zAQENfAyhHN

---
_Generated by [Claude Code](https://claude.ai/code/session_019woWQnM6md3zAQENfAyhHN)_